### PR TITLE
ci: Don't fail coverage, just informational

### DIFF
--- a/{{cookiecutter.project_name}}/codecov.yml
+++ b/{{cookiecutter.project_name}}/codecov.yml
@@ -3,8 +3,10 @@ coverage:
     project:
       default:
         target: "100"
+        informational: true
     patch:
       default:
         target: "100"
+        informational: true
 comment:
   require_changes: true

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -82,7 +82,6 @@ branch = true
 source = ["{{ cookiecutter.project_slug }}"]
 
 [tool.coverage.report]
-fail_under = 100
 exclude_lines = [
   "pragma: no cover",
   "def __repr__",


### PR DESCRIPTION
## Description

<!-- Add a detailed description of the changes if needed. -->

Make coverage only informational. It is more useful this way.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [x] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
