### PR TITLE
cookie: Set line length limit to 88 (and format code)

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -13,7 +13,9 @@ def remove_file(filepath: Union[str, Path]) -> None:
     Path.unlink(PROJECT_DIR / filepath)
 
 
-def add_symlink(path: Path, target: Union[str, Path], target_is_directory: bool = False) -> None:
+def add_symlink(
+    path: Path, target: Union[str, Path], target_is_directory: bool = False
+) -> None:
     """Add symbolic link to target."""
     if path.is_symlink():
         path.unlink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ sphinx-rtd-theme = "^0.5.2"
 
 [tool.flakehell]
 format = "grouped"
-max_line_length = 99
+max_line_length = 88 
 show_source = true
 docstring-convention = "google"
 extended_default_ignore = []  # added to temporarily fix flakehell issue
@@ -82,12 +82,12 @@ multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
-line_length = 99
+line_length = 88
 known_third_party = ["cookiecutter", "invoke", "nox", "pytest", "pytest_cookies"]
 skip = "{{ cookiecutter.project_name }}"
 
 [tool.black]
-line-length = 99
+line-length = 88
 target-version = ["py36"]
 
 [build-system]

--- a/tasks.py
+++ b/tasks.py
@@ -110,7 +110,10 @@ def hooks(c):
     _run(c, "poetry run pre-commit run --all-files")
 
 
-@task(name="format", help={"check": "Checks if source is formatted without applying changes"})
+@task(
+    name="format",
+    help={"check": "Checks if source is formatted without applying changes"},
+)
 def format_(c, check=False):
     # type: (Context, bool) -> None
     """Format code."""
@@ -173,7 +176,11 @@ def docs(c, serve=True, open_browser=True):
     if open_browser:
         webbrowser.open(DOCS_INDEX.absolute().as_uri())
     if serve:
-        _run(c, f"poetry run watchmedo shell-command -p '*.rst;*.md' -c '{build_docs}' -R -D .")
+        options = "shell-command -p '*.rst;*.md' -c '{build_docs}' -R -D ."
+        _run(
+            c,
+            f"poetry run watchmedo {options}",
+        )
 
 
 @task(pre=[format_, tests, lint, mypy])

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -11,7 +11,9 @@ import pytest
 from cookiecutter.utils import rmtree
 from pytest_cookies.plugin import Cookies, Result
 
-skip_on_windows = pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32", reason="does not run on windows"
+)
 
 COOKIE_CONTEXT_NOT_OPEN_SOURCE = {"open_source_license": "Not open source"}
 COOKIE_CONTEXT_CLI = {"command_line_interface": "Click"}
@@ -92,7 +94,9 @@ def test_bake_with_defaults(cookies: Cookies) -> None:
 
 def test_bake_not_open_source(cookies: Cookies) -> None:
     """Test bake not open-source project."""
-    with bake_in_temp_dir(cookies, extra_context=COOKIE_CONTEXT_NOT_OPEN_SOURCE) as result:
+    with bake_in_temp_dir(
+        cookies, extra_context=COOKIE_CONTEXT_NOT_OPEN_SOURCE
+    ) as result:
         assert result.project.isdir()
         assert result.exit_code == 0
         assert result.exception is None


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->
cookie: Set line length limit to 88 (and format code) to make it more readable in smaller screens.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->