### PR TITLE
Fix errors on Windows with recent versions of poetry

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,0 +1,3 @@
+poetry==1.1.8
+poetry-core==1.0.4
+nox==2021.6.12

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Install system deps
         shell: bash
         run: |
-          pip install nox
-          pip install poetry
+          pip install --constraint=.github/workflows/constraints.txt nox poetry poetry-core
           poetry config virtualenvs.in-project true
 
       - name: Run mypy with nox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Install system deps
         shell: bash
         run: |
-          pip install nox
-          pip install poetry
+          pip install --constraint=.github/workflows/constraints.txt nox poetry poetry-core
           poetry config virtualenvs.in-project true
 
       - name: Run tests with nox

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -70,7 +70,7 @@ sphinx-rtd-theme = "^0.5.2"
 autodocsumm = "^0.2.4"
 recommonmark = "^0.7.1"
 bump2version = "^1.0.1"
-pytest = "^6.2.2"
+pytest = "6.2.4"
 xdoctest = "^0.15.4"
 coverage = {version = "^5.3", extras = ["toml"]}
 pytest-cov = "^2.10.1"


### PR DESCRIPTION
-------

## Description
Recent versions of poetry are having errors on Windows and the projects can't be installed.

This should be temporary and the versions should be updated when the issue is resolved.

## Related Issue
This is related to this poetry issue python-poetry/poetry#4535.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [x] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->