### PR TITLE
[cookie][deps][bug] Fix issue with lint in ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         types: [python]
         require_serial: true
         additional_dependencies: [
-          'flake8>=3.8.4',
+          'flake8==3.8.4',
           'flakehell>=0.9.0',
           'flake8-builtins>=1.5.3',
           'flake8-blind-except>=0.2.0',


### PR DESCRIPTION
## Description

This a temporary solution and requires pinning the flake8 version.

<!-- Add a detailed description of the changes if needed. -->

## Related Issue

This is related to the flakehell/flakehell#19

<!-- If your PR refers to a related issue, link it here using `fix #[number-of-issue]`. -->
<!-- If this is not related to an issue, please delete this section (`Related Issue`). -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [x] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->