### PR TITLE
# Fix link to contributing guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details, see the [tutorial][tutorial].
   All contributions are welcome!
 
   Will find a detailed description of all the ways you can contribute to cookiecutter-modern-pypackage in
-  [the contributing guide][contributing_guide] .
+  the [contributing guide][contributing_guide].
 
   This is a beginner-friendly project so don't hesitate to ask any questions or get in touch
   with the project's maintainers.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,1 +1,235 @@
-../CONTRIBUTING.md
+# Contributing
+
+Thank you for your interest in improving this project.
+
+All contributions are welcome and greatly appreciated! Every little bit improves the
+project and helps its users.
+
+The following sections detail a variety of ways to contribute and how to get started.
+
+Credit will always be given to the people making contributions.
+
+If you do decide to work on an issue, please indicate so in a comment to the issue
+so it's assigned to you and other people don't work on it simultaneously.
+
+This is a beginner-friendly project so don't hesitate to write a comment in the issue you are
+interested in if you have questions, would like to discuss some issue further, or you need help
+in any way.
+
+## Types of Contributions
+
+### Spread the word
+Tell others about your experience with cookiecutter-modern-pypackage. You can share it on social media and follow it on GitHub.
+
+### Submit Feedback
+
+The best way to send feedback is to file an issue at
+ <https://github.com/mario-bermonti/cookiecutter-modern-pypackage/issues>.
+
+Please let us know about your experience using cookiecutter-modern-pypackage. You can tell us about the things that you like, the things that can be improved, and the things that you would like cookiecutter-modern-pypackage to do.
+
+If you are proposing a feature:
+
+- How it would help you and other users (mainly researchers).
+- Explain all the details of how it would work.
+- Keep the scope as narrow as possible to make it easier to implement.
+- Remember that this is a volunteer-driven project and for this reason it may not be feasible
+  to implement the feature or it may take some time.
+
+### Write Documentation
+
+cookiecutter-modern-pypackage could always use more documentation. You can contribute to the documentation
+by:
+- Fixing typographical, grammatical, or spelling errors.
+- Improving documentation that is unclear or incorrect.
+- Creating or improving examples and tutorials.
+- Writing blog posts, articles, and similar content that share how you are using this project and your best practices with us.
+
+### Report Bugs
+  You can report bugs at <https://github.com/mario-bermonti/cookiecutter-modern-pypackage/issues>.
+
+  Please provide all the details that are asked when you create the issue to make sure
+  it is understood correctly.
+
+### Fix existing bugs
+
+  Look through the GitHub issues for bugs. Anything tagged with \"bug\"
+  and \"help wanted\" is open to whoever wants to implement it.
+
+### Implement Features
+
+Look through the GitHub issues for features. Anything tagged with
+\"enhancement\" and \"help wanted\" is open to whoever wants to
+implement it.
+
+## Start contributing!
+
+### Set up the development environment
+
+Ready to contribute? Here\'s how to set up
+cookiecutter-modern-pypackage in your local development environment.
+
+You will need [Python 3.6+][download_python] installed.
+
+1.  Fork the [cookiecutter-modern-pypackage repo][cookiecutter-modern-pypackage_gh] on GitHub.
+2.  Clone your fork locally:
+
+        git clone git@github.com:your_name_here/cookiecutter-modern-pypackage.git
+
+3. We use `poetry` to manage dependencies. Install it with the following command.
+
+        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+
+4.  Install the project, its dependencies, and the virtualenv:
+
+         poetry install
+
+5. Make sure everything is working properly before making any changes by running `poetry run invoke dev-tasks`.
+
+### Development tasks (important side note)
+In order to run anything inside the virtual environment every command has to be prefixed with `poetry run <command>`.
+
+For example, to run python inside the virtual environment you would run `poetry run python`.
+
+We have most of our development tasks pre-configured to run automatically with invoke.  :grin:
+
+The most important tasks are:
+
+| Command   | Description                |
+|-----------|----------------------------|
+| dev-tasks | Run all development tasks. |
+| format    | Format code.               |
+| tests     | Run tests.                 |
+| coverage  | Create coverage report.    |
+| lint      | Run all linting.           |
+| mypy      | Run mypy.                  |
+| docs      | Build documentation.       |
+| clean     | Run all clean sub-tasks.   |
+
+
+
+You can find see all the development tasks that pre-configured by running `poetry run invoke --list`.
+
+### Making changes
+
+#### Workflow
+
+We work by protecting `master` branch and only merging changes that don't break existing functionality and are tested.
+
+How do we do it?:
+
+1. We identify something that must change
+2. We create an issue on GitHub, if it doesn't already exist
+3. We create a new branch named after the issue we want "fix" (`issue-$TASKNUMBER`)
+4. We make changes and test everything works
+5. Style the code
+6. We then create a pull request to `master` branch that is reviewed and if approved, it is merged
+   into `master`
+
+This way we achieve an easy and scalable development process that avoids merge
+conflicts and long-living branches.
+
+In this method, the `master` branch always has the latest working version of the software, is stable,
+and is working.
+
+#### How to make changes
+
+Follow this steps when working on changes to the project. Please see the `Workflow section` for
+important details about making changes.
+
+1.  Create a branch for local development. All the changes must be in this branch.
+
+        $ git checkout -b name-of-your-bugfix-or-feature
+
+2. Run the all checks to make sure everything is working before making
+   any changes
+
+        $ poetry run invoke dev-tasks
+
+3. Add any changes you want
+3. Add tests for the new changes
+4. Run the tests and make sure they all pass
+
+        $ poetry run invoke tests
+
+4. Edit the documentation if appropriate (this is required for new features)
+5. Make sure the changes to the documentation are correct and that the docs build
+
+        $ poetry run invoke docs
+
+6. Make sure everything is fine (e.g., tests, code style, coverage)
+
+        $ poetry run invoke dev-tasks
+
+   If you find that something is not working as expected, fix it, check that it is working appropriately
+   by running the appropriate invoke command (see `Development tasks section`).
+
+        $ poetry run invoke <command>
+
+   After it is fixed, run all development tasks again
+
+        $ poetry run invoke dev-tasks
+
+7.  Commit your changes and push your branch to GitHub:
+
+        $ git add .
+        $ git commit
+
+    Cookiecutter-Modern-Pypackage follows specific guidelines for commit messages:
+
+    - Make a reference to the relevant GitHub issues in your commit message (e.g., `Fix #1234`)
+      We use imperative mood for commit messages (`fix x`, instead of `fixed x`).
+      See [this commit guide][commit_guide]. A tip is to use a title for your commit message
+      that completes "This commit will..." [Fix issue X].
+    - The subject line should have < 80 chars
+    - Leave one line blank
+    - [Optional] Explain any relevant details or decisions made
+
+8. Push your changes to GitHub
+
+        $ git push origin name-of-your-bugfix-or-feature
+
+9.  Submit a pull request through GitHub (see the `Pull Request Guidelines` section).
+
+#### Pull Request Guidelines
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1.  The pull request should include tests for new functionality.
+2.  If the pull request adds functionality, the docs should be updated.
+3.  The pull request should pass all tests and must work for all the supported Python versions. It
+    must also pass all checks in the GitHub CI.
+
+Feel free to submit your pull request early so we can discuss it and iterate on the process.
+
+### Tips
+
+We really value your contributions and want to integrate your changes. The following are tips to
+improve the probability that your changes are accepted.
+
+- Make sure they don't break existing functionality
+- Include tests for the changes you made
+- Commit often
+- Make small, easy to understand commits (i.e., atomic commits)
+- Keep your changes in the narrowest scope possible (e.g., create tutorial for using the `X object`)
+- It is recommended to open an issue before starting work on anything. This will allow a chance to
+  talk it over with the maintainers and validate your approach.
+
+## Releasing cookiecutter-modern-pypackage
+
+Maintainers, please review [the guide for releasing new versions][release_guide]
+of cookiecutter-modern-pypackage on Github and Pypi.
+
+
+<!-- Credits -->
+<!-- This file was developed based extensively on the contributing guides of many great projects: -->
+<!-- https://github.com/briggySmalls/cookiecutter-pypackage/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/CONTRIBUTING.rst -->
+<!-- https://github.com/pyjanitor-devs/pyjanitor/blob/dev/docs/CONTRIBUTION_TYPES.rst -->
+<!-- https://github.com/cjolowicz/cookiecutter-hypermodern-python/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/CONTRIBUTING.rst -->
+<!-- https://github.com/wemake-services/wemake-python-package/blob/master/%7B%7Bcookiecutter.project_name%7D%7D/CONTRIBUTING.md -->
+<!-- https://github.com/pandas-dev/pandas/blob/master/doc/source/development/contributing.rst#committing-your-code -->
+
+[download_python]: https://www.python.org/downloads/
+[cookiecutter-modern-pypackage_gh]: https://github.com/mario-bermonti/cookiecutter-modern-pypackage
+[commit_guide]: https://chris.beams.io/posts/git-commit/
+[release_guide]: ./release_guide.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Getting Started
    readme
    tutorial
    changelog
-   Contributing <CONTRIBUTING.md>
+   Contributing <CONTRIBUTING>
    Code of Conduct <CODE_OF_CONDUCT>
 
 Basics


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->
The link in the readme file was broken.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->