### PR TITLE
Fix reference to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ This template is also influenced by these awesome projects:
 [pypi]: https://pypi.org/
 [testpypi]: https://test.pypi.org/
 [code_conduct]: ./CODE_OF_CONDUCT.md
-[contributing_guide]: ./CONTRIBUTING.md
+[contributing_guide]: ./contributing.md
 [original_cookie]: https://github.com/fedejaure/cookiecutter-modern-pypackage
 [TezRomacH]: https://github.com/TezRomacH/python-package-template

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Getting Started
    readme
    tutorial
    changelog
-   Contributing <CONTRIBUTING>
+   contributing
    Code of Conduct <CODE_OF_CONDUCT>
 
 Basics


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->
The case of the url (filename) was not the correct one.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change that fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix
- [x] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [project's code of conduct][code_conduct].
- [ ] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->