### PR TITLE
Add reference to publishing to pypi

### DIFF
--- a/{{cookiecutter.project_name}}/docs/release_guide.md
+++ b/{{cookiecutter.project_name}}/docs/release_guide.md
@@ -29,3 +29,7 @@ This guide describes how to release {{ cookiecutter.project_name }} on Github an
    - Add a summary of the changes
    - Revise the draft and make any appropriate changes
 9. Publish the draft on GitHub
+
+The release will be automatically published on pypi. Please check the [GitHub action named
+release pypi](https://github.com/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/actions "release ci")
+passed and check everything is correct in [pypi](https://pypi.org/project/{{ cookiecutter.project_name }}/).


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->
Add a reference to publishing to pypi which is done automatically when a Github release is published.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->