### PR TITLE
Make publishing to pypi optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 * Command line interface using [Click][click] (optional)
 * Automated dependency updates with [Dependabot][dependabot]
 * Coverage reports on [Codecov][codecov]
-* Automated releases to [PyPI][pypi] and [TestPyPI][testpypi]
+* Automated releases to [PyPI][pypi]  (optional)
 
 ## Quickstart
 
@@ -55,7 +55,7 @@ Then:
 * Install pre-commit hooks. (`poetry run inv install-hooks`)
 * Configure [Codecov][codecov] repository settings. (Codecov App, `CODECOV_TOKEN`)
 * Add the repo to your [Read the Docs][rtd] account + turn on the Read the Docs service hook.
-* Configure [PyPI][pypi] and [TestPyPI][testpypi] tokens. (`PYPI_TOKEN`, `TEST_PYPI_TOKEN`)
+* Configure [PyPI][pypi] token. (`PYPI_TOKEN`)
 * Release your package by pushing a new tag.
 
 For more details, see the [tutorial][tutorial].

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,12 +1,14 @@
 {
-  "full_name": "Jean Piaget",
-  "email": "jpiaget@example.com",
-  "github_username": "jpiaget",
-  "project_name": "modern-python-boilerplate",
-  "project_slug": "{{ cookiecutter.project_name.lower().replace('-', '_').replace('-', '_') }}",
-  "project_title": "{{ cookiecutter.project_name.replace('-', ' ').title() }}",
-  "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a modern Python package.",
-  "version": "0.1.0",
+    "full_name": "Jean Piaget",
+    "email": "jpiaget@example.com",
+    "github_username": "jpiaget",
+    "project_name": "modern-python-boilerplate",
+    "project_slug": "{{ cookiecutter.project_name.lower().replace('-', '_').replace('-', '_') }}",
+    "project_title": "{{ cookiecutter.project_name.replace('-', ' ').title() }}",
+    "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a modern Python package.",
+    "version": "0.1.0",
     "open_source_license": ["MIT", "BSD-3", "ISC", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
-  "command_line_interface": ["Click", "No command-line interface"]
+    "command_line_interface": ["Click", "No command-line interface"],
+    "publish_pypi": ["yes", "no"]
+
 }

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -6,7 +6,7 @@ Tutorial
 
 .. _`Edit this file`: https://github.com/mario-bermonti/cookiecutter-modern-pypackage/blob/master/docs/tutorial.rst
 
-To start with, you will need a `GitHub account`_ and an account on `PyPI`_. Create these before you get started on this tutorial. If you are new to Git and GitHub, you should probably spend a few minutes on some of the tutorials at the top of the page at `GitHub Help`_.
+To start with, you will need a `GitHub account`_ and an account on `PyPI`_. You only need the Pypi account if you want to publish to pypi. Create these before you get started on this tutorial. If you are new to Git and GitHub, you should probably spend a few minutes on some of the tutorials at the top of the page at `GitHub Help`_.
 
 .. _`GitHub account`: https://github.com/
 .. _`PyPI`: https://pypi.python.org/pypi
@@ -104,21 +104,20 @@ Now your documentation will get rebuilt when you make documentation changes to y
 
 .. _`Read the Docs`: https://readthedocs.org/
 
-Step 7: Release on PyPI and TestPyPI
+Step 7: Release on PyPI
 ------------------------------------
+
+.. note:: This section only applies if you want to publish your project to PyPI.
 
 The Python Package Index or `PyPI`_ is the official third-party software repository for the Python programming language. Python developers intend it to be a comprehensive catalog of all open source Python packages.
 
-`TestPyPI`_ is a separate instance of the Python Package Index (`PyPI`_) that allows you to try out the distribution tools and process without worrying about affecting the real index.
+Log into your account at `PyPI`_. Go to Account Settings and generate an API tokens.
 
-Log into your account at `PyPI`_ and `TestPyPI`_. Go to Account Settings and generate an API tokens.
-
-Go to the repository settings on GitHub, and add tow secrets named `PYPI_TOKEN` and `TEST_PYPI_TOKEN` with the tokens that you just generated.
+Go to the repository settings on GitHub, and add tow secrets named `PYPI_TOKEN` with the tokens that you just generated.
 
 Release your package by pushing a new tag.
 
 .. _`PyPI`: https://pypi.python.org/pypi
-.. _`TestPyPI`: https://test.pypi.org/
 
 Having problems?
 ----------------

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -6,6 +6,7 @@ PROJECT_DIR = Path.cwd()
 PROJECT_TESTS = PROJECT_DIR / Path("tests")
 PROJECT_SRC = PROJECT_DIR / Path("src/{{ cookiecutter.project_slug }}")
 PROJECT_DOCS = PROJECT_DIR / Path("docs")
+PROJECT_CI_RELEASE_PYPI = PROJECT_DIR / Path(".github/workflows/release_pypi.yml")
 
 
 def remove_file(filepath: Union[str, Path]) -> None:
@@ -32,6 +33,9 @@ if __name__ == "__main__":
         remove_file("LICENSE.rst")
     else:
         add_symlink(PROJECT_DOCS / "license.rst", "../LICENSE.rst")
+
+    if "no" == "{{ cookiecutter.publish_pypi }}":
+        remove_file(PROJECT_CI_RELEASE_PYPI)
 
     add_symlink(PROJECT_DOCS / "readme.md", "../README.md")
     add_symlink(PROJECT_DOCS / "changelog.md", "../CHANGELOG.md")

--- a/{{cookiecutter.project_name}}/CHANGELOG.md
+++ b/{{cookiecutter.project_name}}/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [{{ cookiecutter.version }}] - {% now 'local' %}
 ### Added
-- First release on PyPI.
+- First release.
 
 [Unreleased]: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/compare/v{{ cookiecutter.version }}...HEAD
 [{{ cookiecutter.version }}]: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/compare/releases/tag/v{{ cookiecutter.version }}

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -2,8 +2,10 @@
 # {{ cookiecutter.project_title }}
 
 {% if is_open_source %}
+  {% if cookiecutter.publish_pypi == "yes" %}
 [![PyPI - Version](https://img.shields.io/pypi/v/{{ cookiecutter.project_name }}.svg)](https://pypi.python.org/pypi/{{ cookiecutter.project_name }})
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/{{ cookiecutter.project_name }}.svg)](https://pypi.python.org/pypi/{{ cookiecutter.project_name }})
+  {% endif %}
 ![GitHub](https://img.shields.io/github/license/mario-bermonti/{{ cookiecutter.project_name }})
 [![Tests](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/workflows/tests/badge.svg)](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/actions?workflow=tests)
 [![Codecov](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}/branch/master/graph/badge.svg?token=YOURTOKEN)](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }})

--- a/{{cookiecutter.project_name}}/docs/contributing.md
+++ b/{{cookiecutter.project_name}}/docs/contributing.md
@@ -218,7 +218,7 @@ improve the probability that your changes are accepted.
 ## Releasing {{ cookiecutter.project_name }}
 
 Maintainers, please review [the guide for releasing new versions][release_guide]
-of {{ cookiecutter.project_name }} on Github and Pypi.
+of {{ cookiecutter.project_name }}.
 
 
 <!-- Credits -->

--- a/{{cookiecutter.project_name}}/docs/release_guide.md
+++ b/{{cookiecutter.project_name}}/docs/release_guide.md
@@ -1,6 +1,6 @@
 # Release guide
 
-This guide describes how to release {{ cookiecutter.project_name }} on Github and Pypi.
+This guide describes how to release {{ cookiecutter.project_name }}.
 
 1. Create new branch named `bump-{{ cookiecutter.project_name }}-version-[version-number]`.
 2. Add a label to the branch that describes the part of the version number that
@@ -30,6 +30,8 @@ This guide describes how to release {{ cookiecutter.project_name }} on Github an
    - Revise the draft and make any appropriate changes
 9. Publish the draft on GitHub
 
+{% if cookiecutter.publish_pypi == "yes" %}
 The release will be automatically published on pypi. Please check the [GitHub action named
 release pypi](https://github.com/{{ cookiecutter.project_name }}/{{ cookiecutter.project_name }}/actions "release ci")
 passed and check everything is correct in [pypi](https://pypi.org/project/{{ cookiecutter.project_name }}/).
+{% endif %}


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->
This required that the cookie and the template were modified. Change impact both
docs, as well as the process for creating new templates.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->