### PR TITLE
Use default readthedocs url instead of a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python Version](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue?logo=python)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen)](https://opensource.org/licenses/MIT)
 [![Tests](https://github.com/mario-bermonti/cookiecutter-modern-pypackage/workflows/tests/badge.svg)](https://github.com/mario-bermonti/cookiecutter-modern-pypackage/actions?workflow=tests)
-[![Read the Docs](https://readthedocs.org/projects/cookiecutter-modern-python-package/badge/?version=latest)](https://cookiecutter-modern-python-package.readthedocs.io/en/latest/)
+[![Read the Docs](https://readthedocs.org/projects/cookiecutter-modern-python-package/badge/?version=latest)](https://cookiecutter-modern-python-package.readthedocs.io)
 [![Black](https://img.shields.io/badge/code%20style-black-000000)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
@@ -12,7 +12,7 @@
 [Cookiecutter][cookiecutter] template for a modern Python package.
 
 * GitHub repo: <https://github.com/mario-bermonti/cookiecutter-modern-pypackage.git>
-* Documentation: <https://cookiecutter-modern-python-package.readthedocs.io/en/latest/>
+* Documentation: <https://cookiecutter-modern-python-package.readthedocs.io>
 * Free software: MIT license
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "MIT"
 homepage = "https://github.com/mario-bermonti/cookiecutter-modern-pypackage"
 repository = "https://github.com/mario-bermonti/cookiecutter-modern-pypackage"
-documentation = "https://cookiecutter-modern-python-package.readthedocs.io/en/latest/"
+documentation = "https://cookiecutter-modern-python-package.readthedocs.io"
 keywords=["cookiecutter", "template", "package"]
 classifiers=[
     "Development Status :: 4 - Beta",

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -17,7 +17,7 @@ license = "{{ cookiecutter.open_source_license }}"
 readme = "README.md"
 homepage = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}"
 repository = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}"
-documentation = "https://{{ cookiecutter.project_name }}.readthedocs.io/en/latest/"
+documentation = "https://{{ cookiecutter.project_name }}.readthedocs.io"
 keywords = ["{{ cookiecutter.project_name }}"]
 classifiers=[
     "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
## Description

<!-- Add a detailed description of the changes if needed. -->
This makes rtd manage the version to which to redirect.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->