### PR TITLE
Fix link to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This template is also influenced by these awesome projects:
 [sphinx]: https://www.sphinx-doc.org/en/master/
 [rtd]: https://readthedocs.org/
 [nox]: https://nox.thea.codes/en/stable/
-[tutorial]: https://cookiecutter-modern-pypackage.readthedocs.io/en/latest/tutorial.html
+[tutorial]: https://cookiecutter-modern-python-package.readthedocs.io/en/latest/tutorial.html
 [click]: http://click.pocoo.org/
 [dependabot]: https://dependabot.com/
 [audreyr/cookiecutter-pypackage]: https://github.com/audreyr/cookiecutter-pypackage


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->
It pointed to fedejaure/cookiecutter-modern-pypackage tutorial.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->